### PR TITLE
Fix 7.17.7 version

### DIFF
--- a/siren-nlp.md
+++ b/siren-nlp.md
@@ -35,4 +35,4 @@ For more details, see our [documentation](https://docs.support.siren.io/siren-nl
 | 7.17.4 | [7.17.4-0.5.5](https://download.support.siren.io/plugins/siren-nlp/siren-nlp-7.17.4-0.5.5.zip) |
 | 7.17.5 | [7.17.5-0.5.5](https://download.support.siren.io/plugins/siren-nlp/siren-nlp-7.17.5-0.5.5.zip) |
 | 7.17.6 | [7.17.6-0.5.5](https://download.support.siren.io/plugins/siren-nlp/siren-nlp-7.17.6-0.5.5.zip) |
-| 7.17.7 0.5.5 | [7.17.7-0.5.5](https://download.support.siren.io/plugins/siren-nlp/siren-nlp-7.17.7-0.5.5.zip) |
+| 7.17.7 | [7.17.7-0.5.5](https://download.support.siren.io/plugins/siren-nlp/siren-nlp-7.17.7-0.5.5.zip) |


### PR DESCRIPTION
Fix the broken 7.17.7 version of ES that was pushed by the automated release process.

# before
![image](https://user-images.githubusercontent.com/8244036/207336383-31b7abba-7efd-4070-afd6-dea82a4756ae.png)
