### PR TITLE
Manually remove duplicate NLP links

### DIFF
--- a/siren-nlp.md
+++ b/siren-nlp.md
@@ -40,5 +40,3 @@ For more details, see our [documentation](https://docs.support.siren.io/siren-nl
 | 7.17.9 | [7.17.9-0.5.5](https://download.support.siren.io/plugins/siren-nlp/siren-nlp-7.17.9-0.5.5.zip) |
 | 7.17.10 | [7.17.10-0.5.5](https://download.support.siren.io/plugins/siren-nlp/siren-nlp-7.17.10-0.5.5.zip) |
 | 8.7.1 | [8.7.1-0.5.6](https://download.support.siren.io/plugins/siren-nlp/siren-nlp-8.7.1-0.5.6.zip) |
-| 8.7.1 | [8.7.1-0.5.6](https://download.support.siren.io/plugins/siren-nlp/siren-nlp-8.7.1-0.5.6.zip) |
-| 8.7.1 | [8.7.1-0.5.6](https://download.support.siren.io/plugins/siren-nlp/siren-nlp-8.7.1-0.5.6.zip) |


### PR DESCRIPTION
There were multiple siren-nlp links as the release job was run multiple times on the same tag.
(This blindly creates a new link for each run without checking the existing table entries)